### PR TITLE
enabled sitemap generation through sphinx module in the docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,3 +6,6 @@ exclude_patterns = ["out/**"]
 # it should be a .ico and in addition there is no favicon.png in this project
 # so it can't find the file
 html_favicon = None
+
+site_url = 'https://crate.io/docs/crate/getting-started/en/latest/'
+extensions = ['sphinx_sitemap']


### PR DESCRIPTION
* added extension to `docs/conf.py`
* set base url in `docs/conf.py`
* this will automatically generate a sitemap for every docs build